### PR TITLE
Add embedding metadata sidecars to similarity/diversity scripts

### DIFF
--- a/similarity_research/diversity_research/script_diversity_classical_cv.py
+++ b/similarity_research/diversity_research/script_diversity_classical_cv.py
@@ -49,6 +49,9 @@ Usage:
 
 import sys
 import logging
+import datetime
+import json
+import subprocess
 from pathlib import Path
 from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
@@ -57,6 +60,30 @@ import numpy as np
 import pandas as pd
 from PIL import Image, ImageDraw, ImageFont
 from fontTools.ttLib import TTFont
+
+
+def write_metadata(
+    output_dir: Path,
+    model: dict,
+    rendering: dict,
+    embeddings: List[dict],
+) -> None:
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        commit = None
+    payload = {
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "git_commit": commit,
+        "model": model,
+        "rendering": rendering,
+        "embeddings": embeddings,
+    }
+    (output_dir / "metadata.json").write_text(json.dumps(payload, indent=2) + "\n")
 
 # Classical CV imports
 try:
@@ -571,6 +598,29 @@ def main():
         all_pairs.append(pd.read_csv(f))
     if all_pairs:
         pd.concat(all_pairs).to_csv(OUTPUT_DIR / "all_font_pairwise.csv", index=False)
+
+    write_metadata(
+        OUTPUT_DIR,
+        model={
+            "name": "Classical CV",
+            "weights": "hand-engineered features",
+            "feature_dim": int(result["feature_dim"].iloc[0]) if not result.empty else None,
+        },
+        rendering={
+            "canvas_size": CANVAS_SIZE,
+            "font_render_size": FONT_RENDER_SIZE,
+            "max_fonts_per_script": MAX_FONTS_PER_SCRIPT,
+        },
+        embeddings=[
+            {
+                "file": f"embeddings/{row['script']}_classical_features.npy",
+                "names_file": f"embeddings/{row['script']}_font_names.csv",
+                "script": row["script"],
+                "rows": int(row["fonts_analyzed"]),
+            }
+            for _, row in result.iterrows()
+        ],
+    )
 
     logger.info(f"Saved → {OUTPUT_DIR}/")
 

--- a/similarity_research/diversity_research/script_diversity_cnn_100.py
+++ b/similarity_research/diversity_research/script_diversity_cnn_100.py
@@ -37,6 +37,9 @@ Usage:
 import os
 import sys
 import logging
+import datetime
+import json
+import subprocess
 from pathlib import Path
 from collections import defaultdict
 from typing import Dict, List, Optional
@@ -48,6 +51,31 @@ import torch.nn as nn
 from torchvision import models, transforms
 from PIL import Image, ImageDraw, ImageFont
 from fontTools.ttLib import TTFont
+
+
+def write_metadata(
+    output_dir: Path,
+    model: dict,
+    rendering: dict,
+    embeddings: List[dict],
+) -> None:
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        commit = None
+    payload = {
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "git_commit": commit,
+        "model": model,
+        "rendering": rendering,
+        "embeddings": embeddings,
+    }
+    (output_dir / "metadata.json").write_text(json.dumps(payload, indent=2) + "\n")
+
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -1211,6 +1239,11 @@ def run_pipeline(fonts_dir: Path) -> pd.DataFrame:
 
         # Save embeddings
         np.save(EMBEDDINGS_DIR / f"{script_name}_embeddings.npy", matrix)
+        pd.DataFrame({
+            "font_name": font_names,
+            "script": script_name,
+            "row_index": range(len(font_names)),
+        }).to_csv(EMBEDDINGS_DIR / f"{script_name}_font_names.csv", index=False)
 
         results.append({
             "script": script_name,
@@ -1288,6 +1321,29 @@ def main():
                        "fonts_analyzed", "reference_chars", "glyphs_rendered"]].copy()
     summary.to_csv(OUTPUT_DIR / "diversity_index_summary.csv", index=False)
     logger.info(f"Saved → {OUTPUT_DIR / 'diversity_index_summary.csv'}")
+
+    write_metadata(
+        OUTPUT_DIR,
+        model={
+            "name": "ResNet50",
+            "weights": "IMAGENET1K_V1",
+            "feature_dim": 2048,
+        },
+        rendering={
+            "canvas_size": CANVAS_SIZE,
+            "font_render_size": FONT_RENDER_SIZE,
+            "max_fonts_per_script": MAX_FONTS_PER_SCRIPT,
+        },
+        embeddings=[
+            {
+                "file": f"embeddings/{row['script']}_embeddings.npy",
+                "names_file": f"embeddings/{row['script']}_font_names.csv",
+                "script": row["script"],
+                "rows": int(row["fonts_analyzed"]),
+            }
+            for _, row in result.iterrows()
+        ],
+    )
 
 
 if __name__ == "__main__":

--- a/similarity_research/diversity_research/script_diversity_vit_100.py
+++ b/similarity_research/diversity_research/script_diversity_vit_100.py
@@ -37,6 +37,9 @@ Usage:
 import os
 import sys
 import logging
+import datetime
+import json
+import subprocess
 from pathlib import Path
 from collections import defaultdict
 from typing import Dict, List, Optional
@@ -48,6 +51,31 @@ import torch.nn as nn
 from torchvision import models, transforms
 from PIL import Image, ImageDraw, ImageFont
 from fontTools.ttLib import TTFont
+
+
+def write_metadata(
+    output_dir: Path,
+    model: dict,
+    rendering: dict,
+    embeddings: List[dict],
+) -> None:
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        commit = None
+    payload = {
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "git_commit": commit,
+        "model": model,
+        "rendering": rendering,
+        "embeddings": embeddings,
+    }
+    (output_dir / "metadata.json").write_text(json.dumps(payload, indent=2) + "\n")
+
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -1211,6 +1239,11 @@ def run_pipeline(fonts_dir: Path) -> pd.DataFrame:
 
         # Save embeddings
         np.save(EMBEDDINGS_DIR / f"{script_name}_embeddings.npy", matrix)
+        pd.DataFrame({
+            "font_name": font_names,
+            "script": script_name,
+            "row_index": range(len(font_names)),
+        }).to_csv(EMBEDDINGS_DIR / f"{script_name}_font_names.csv", index=False)
 
         results.append({
             "script": script_name,
@@ -1288,6 +1321,29 @@ def main():
                        "fonts_analyzed", "reference_chars", "glyphs_rendered"]].copy()
     summary.to_csv(OUTPUT_DIR / "diversity_index_summary.csv", index=False)
     logger.info(f"Saved → {OUTPUT_DIR / 'diversity_index_summary.csv'}")
+
+    write_metadata(
+        OUTPUT_DIR,
+        model={
+            "name": "ViT-B/16",
+            "weights": "IMAGENET1K_V1",
+            "feature_dim": 768,
+        },
+        rendering={
+            "canvas_size": CANVAS_SIZE,
+            "font_render_size": FONT_RENDER_SIZE,
+            "max_fonts_per_script": MAX_FONTS_PER_SCRIPT,
+        },
+        embeddings=[
+            {
+                "file": f"embeddings/{row['script']}_embeddings.npy",
+                "names_file": f"embeddings/{row['script']}_font_names.csv",
+                "script": row["script"],
+                "rows": int(row["fonts_analyzed"]),
+            }
+            for _, row in result.iterrows()
+        ],
+    )
 
 
 if __name__ == "__main__":

--- a/similarity_research/diversity_research/script_diversity_vit_pipeline.py
+++ b/similarity_research/diversity_research/script_diversity_vit_pipeline.py
@@ -48,6 +48,9 @@ Usage:
 import os
 import sys
 import logging
+import datetime
+import json
+import subprocess
 from pathlib import Path
 from collections import defaultdict
 from typing import Dict, List, Tuple, Optional
@@ -60,6 +63,30 @@ from torchvision import models, transforms
 from PIL import Image, ImageDraw, ImageFont
 from fontTools.ttLib import TTFont
 from itertools import combinations
+
+
+def write_metadata(
+    output_dir: Path,
+    model: dict,
+    rendering: dict,
+    embeddings: List[dict],
+) -> None:
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        commit = None
+    payload = {
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "git_commit": commit,
+        "model": model,
+        "rendering": rendering,
+        "embeddings": embeddings,
+    }
+    (output_dir / "metadata.json").write_text(json.dumps(payload, indent=2) + "\n")
 
 # ---------------------------------------------------------------------------
 # Configuration
@@ -666,6 +693,11 @@ def run_diversity_pipeline(
         # Also save embeddings for later visualization
         embedding_path = EMBEDDINGS_DIR / f"{script_name}_embeddings.npy"
         np.save(embedding_path, font_avg_matrix)
+        pd.DataFrame({
+            "font_name": font_names_used,
+            "script": script_name,
+            "row_index": range(len(font_names_used)),
+        }).to_csv(EMBEDDINGS_DIR / f"{script_name}_font_names.csv", index=False)
 
         results.append({
             "script": script_name,
@@ -806,6 +838,29 @@ def main():
                           "fonts_analyzed"]].copy()
     summary.to_csv(OUTPUT_DIR / "diversity_index_summary.csv", index=False)
     logger.info(f"Saved summary → {OUTPUT_DIR / 'diversity_index_summary.csv'}")
+
+    write_metadata(
+        OUTPUT_DIR,
+        model={
+            "name": "ViT-B/16",
+            "weights": "IMAGENET1K_V1",
+            "feature_dim": 768,
+        },
+        rendering={
+            "canvas_size": CANVAS_SIZE,
+            "font_render_size": FONT_RENDER_SIZE,
+            "padding": PADDING,
+        },
+        embeddings=[
+            {
+                "file": f"embeddings/{row['script']}_embeddings.npy",
+                "names_file": f"embeddings/{row['script']}_font_names.csv",
+                "script": row["script"],
+                "rows": int(row["fonts_analyzed"]),
+            }
+            for _, row in result_df.iterrows()
+        ],
+    )
 
     return result_df
 

--- a/similarity_research/script_similarity_cnn.py
+++ b/similarity_research/script_similarity_cnn.py
@@ -2,6 +2,10 @@ from pathlib import Path
 from collections import defaultdict
 from typing import Dict, List, Optional
 
+import datetime
+import json
+import subprocess
+
 import numpy as np
 import pandas as pd
 import torch
@@ -38,6 +42,30 @@ MIN_CODEPOINT_COVERAGE = 10
 MIN_SUPPORTED_REFERENCE_CHARS = 3
 
 REFERENCE_SCRIPT = "Latin"
+
+
+def write_metadata(
+    output_dir: Path,
+    model: dict,
+    rendering: dict,
+    embeddings: List[dict],
+) -> None:
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        commit = None
+    payload = {
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "git_commit": commit,
+        "model": model,
+        "rendering": rendering,
+        "embeddings": embeddings,
+    }
+    (output_dir / "metadata.json").write_text(json.dumps(payload, indent=2) + "\n")
 
 TARGET_SCRIPTS = {
     "Latin":       [(0x0041, 0x005A), (0x0061, 0x007A)],
@@ -337,6 +365,7 @@ def run_similarity(fonts_dir: Path):
             font_paths = list(np.random.choice(font_paths, MAX_FONTS_PER_SCRIPT, replace=False))
 
         font_avg_embeddings = []
+        accepted_fonts: List[str] = []
         glyph_count_total = 0
 
         for idx, font_path in enumerate(font_paths):
@@ -362,6 +391,7 @@ def run_similarity(fonts_dir: Path):
             font_avg = np.mean(glyph_embeddings, axis=0)
             font_avg = normalize(font_avg)
             font_avg_embeddings.append(font_avg)
+            accepted_fonts.append(Path(font_path).stem)
 
         if len(font_avg_embeddings) < 2:
             logger.warning(f"Skipping {script_name}")
@@ -370,6 +400,11 @@ def run_similarity(fonts_dir: Path):
         font_matrix = np.vstack(font_avg_embeddings)
         script_font_embeddings[script_name] = font_matrix
         np.save(EMBEDDINGS_DIR / f"{script_name}_font_embeddings.npy", font_matrix)
+        pd.DataFrame({
+            "font_name": accepted_fonts,
+            "script": script_name,
+            "row_index": range(len(accepted_fonts)),
+        }).to_csv(EMBEDDINGS_DIR / f"{script_name}_font_names.csv", index=False)
 
         summary_rows.append({
             "script": script_name,
@@ -414,6 +449,32 @@ def main():
 
     similarity.to_csv(OUTPUT_DIR / "cnn_script_similarity_matrix.csv")
     summary.to_csv(OUTPUT_DIR / "cnn_script_similarity_summary.csv", index=False)
+
+    write_metadata(
+        OUTPUT_DIR,
+        model={
+            "name": "ResNet50",
+            "weights": "IMAGENET1K_V1",
+            "feature_dim": 2048,
+        },
+        rendering={
+            "canvas_size": CANVAS_SIZE,
+            "font_render_size": FONT_RENDER_SIZE,
+            "max_fonts_per_script": MAX_FONTS_PER_SCRIPT,
+            "min_supported_reference_chars": MIN_SUPPORTED_REFERENCE_CHARS,
+            "min_codepoint_coverage": MIN_CODEPOINT_COVERAGE,
+            "reference_script": REFERENCE_SCRIPT,
+        },
+        embeddings=[
+            {
+                "file": f"embeddings/{row['script']}_font_embeddings.npy",
+                "names_file": f"embeddings/{row['script']}_font_names.csv",
+                "script": row["script"],
+                "rows": int(row["fonts_analyzed"]),
+            }
+            for _, row in summary.iterrows()
+        ],
+    )
 
     print("Done.")
     print(summary)


### PR DESCRIPTION
Each output directory now writes a metadata.json describing the model, rendering config, and per-script embedding files. Each .npy embedding file gets a sibling {script}_font_names.csv mapping row index -> font.

This makes embedding outputs self-describing and prevents the kind of "which model produced this?" confusion that led to multiple near-identical vit_outputs* directories.

- similarity_research/script_similarity_cnn.py
- similarity_research/diversity_research/script_diversity_vit_pipeline.py
- similarity_research/diversity_research/script_diversity_vit_100.py
- similarity_research/diversity_research/script_diversity_cnn_100.py
- similarity_research/diversity_research/script_diversity_classical_cv.py