### PR TITLE
heatmap: add Google Fonts to subtitle as the data source

### DIFF
--- a/data/viz/heatmap.html
+++ b/data/viz/heatmap.html
@@ -128,7 +128,7 @@
 
 <h1>Script Servedness Score (SSS)</h1>
 <p class="subtitle">
-  TRC / Monotype / Sawyer Lab | All values normalized 0-1 | Sorted by SSS (best served first)
+  TRC / Monotype / Sawyer Lab | Data: Google Fonts | All values normalized 0-1 | Sorted by SSS (best served first)
 </p>
 
 <div class="heatmap-wrap">

--- a/docs/viz/heatmap.html
+++ b/docs/viz/heatmap.html
@@ -128,7 +128,7 @@
 
 <h1>Script Servedness Score (SSS)</h1>
 <p class="subtitle">
-  TRC / Monotype / Sawyer Lab | All values normalized 0-1 | Sorted by SSS (best served first)
+  TRC / Monotype / Sawyer Lab | Data: Google Fonts | All values normalized 0-1 | Sorted by SSS (best served first)
 </p>
 
 <div class="heatmap-wrap">


### PR DESCRIPTION
Adding "Data: Google Fonts" makes the actual provenance explicit.