### PR TITLE
Pin source-data snapshots for reproducibility (follow-up to #44)

### DIFF
--- a/data/final/README.md
+++ b/data/final/README.md
@@ -36,3 +36,18 @@ Robustness & sensitivity report — diversity-model rank correlations (ViT/ResNe
 classical), the log-demand denominator vs the original epsilon, demand sensitivity,
 and tier stability across diversity models. Regenerate with
 `uv run python analysis/robustness.py`.
+
+## Source data snapshots
+
+For citation and reproducibility, the committed index inputs derive from these
+pinned sources (record new values here whenever an index is regenerated):
+
+| Input | Source | Pinned snapshot |
+|---|---|---|
+| Exposure (demand) | HTTP Archive `crawl.requests` via BigQuery | **2026-03-01 monthly crawl**, desktop client |
+| Support (font families) | Google Fonts Developer API | API pull, June 2026 (date not recorded — record on next refresh) |
+| Diversity + Complexity | `github.com/google/fonts` clone | commit `TBD` — maintainers: run `git -C "$GOOGLE_FONTS_DIR" rev-parse HEAD` and record here |
+
+The diversity/complexity indices are computed from font binaries in the Google
+Fonts clone, so the clone's commit SHA is the definitive version pin for the
+paper. The demand pull is reproducible given the crawl date + client above.

--- a/exposure_research/DEMAND_PROVENANCE.md
+++ b/exposure_research/DEMAND_PROVENANCE.md
@@ -87,3 +87,9 @@ denominator is nearly constant, so the SSS ordering reduces to effective choice 
 consistent with the documented result that the underserved ordering does not depend
 on demand (ρ = 1.00). The §4 roadmap (validate the `subset=` share before trusting
 demand levels) still stands.
+
+**Reproducibility note (per review on PR #44):** the demand pull is parameterized
+by crawl — the committed numbers come from the **2026-03-01 HTTP Archive monthly
+crawl** (`HTTPARCHIVE_CRAWL_DATE`, desktop client). Given the same crawl date and
+client, the pull is reproducible; the caveats above are about *attribution*
+(coverage vs `subset=`), not about run-to-run drift.


### PR DESCRIPTION
Follow-up to the review notes on #44 (docs only, no code or data changes):

- **`DEMAND_PROVENANCE.md`** — records that the committed demand numbers come from the **2026-03-01 HTTP Archive monthly crawl** (desktop client), so the pull is reproducible given crawl date + client; the open caveats are about *attribution* (coverage vs `subset=`), not run-to-run drift.
- **`data/final/README.md`** — adds a **source-snapshots table** pinning all three inputs (HTTP Archive crawl · Google Fonts API pull · `google/fonts` clone commit). The fonts-clone SHA is the definitive version pin for the diversity/complexity indices — @ljvaughn0841, once you have `git -C "$GOOGLE_FONTS_DIR" rev-parse HEAD`, drop it in and this is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013vMcZo9KPqYDpC3cMaHtJh)_